### PR TITLE
Add hero template and page redesign

### DIFF
--- a/public/about.php
+++ b/public/about.php
@@ -1,4 +1,13 @@
-<?php include 'includes/header.php'; ?>
-<h1>About Us</h1>
-<p>Learn more about our studio and philosophy.</p>
+<?php
+$title = 'About';
+$bg    = 'https://images.unsplash.com/photo-1518733057094-95b53151d6c4?auto=format&fit=crop&w=1400&q=80';
+include 'includes/header.php';
+include 'includes/hero.php';
+?>
+<section class="py-5">
+  <div class="container">
+    <h1 class="mb-4">About Us</h1>
+    <p>Learn more about our studio and philosophy.</p>
+  </div>
+</section>
 <?php include 'includes/footer.php'; ?>

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -58,3 +58,20 @@ section { padding: 80px 0; }
   box-shadow: 0 8px 20px rgba(0,0,0,.05);
 }
 .card-img-top { border-top-left-radius: 1rem; border-top-right-radius: 1rem; }
+/* ---------- Page hero ---------- */
+.page-hero {
+  position: relative;
+  min-height: 40vh;
+  background-size: cover;
+  background-position: center;
+  color: var(--light);
+}
+.page-hero__overlay{
+  content:"";position:absolute;inset:0;
+  background:linear-gradient(180deg,rgba(0,0,0,.35),rgba(0,0,0,.6));
+}
+
+/* Links in hero/button hover tweaks */
+.section-title + .row { margin-top: 2rem; }
+.table-info { background-color: rgba(78,138,158,.15) !important; }
+.card-footer .btn { border-radius: 50px; }

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -2,25 +2,29 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap');
 
 :root {
-  --primary: #4e8a9e;      /* акцент: морская волна */
-  --secondary: #f4e8d1;    /* мягкий песочный */
-  --dark: #2b2d42;         /* тёмный текст/фон */
+  --primary: #0aa0f7;      /* технологичный голубой акцент */
+  --secondary: #f0f0f0;    /* светлый фон */
+  --dark: #333333;         /* тёмный текст */
   --light: #ffffff;
 }
+
+html { scroll-behavior: smooth; }
 
 body {
   font-family: 'Poppins', sans-serif;
   color: var(--dark);
-  background-color: #fafafa;
+  background-color: var(--secondary);
 }
 
 /* ---------- Navbar ---------- */
 .navbar-dark.bg-dark {
-  background-color: var(--primary) !important;
+  background-color: var(--light) !important;
+  box-shadow: 0 2px 4px rgba(0,0,0,.04);
 }
-.nav-link.active, .nav-link:hover {
-  color: var(--secondary) !important;
-}
+.navbar-dark .navbar-brand,
+.navbar-dark .nav-link { color: var(--dark); }
+.nav-link.active,
+.nav-link:hover { color: var(--primary) !important; }
 
 /* ---------- Hero ---------- */
 .hero {
@@ -32,11 +36,12 @@ body {
   text-align: center;
   background: url('https://images.unsplash.com/photo-1554290764-4b62c1e6e23c?auto=format&fit=crop&w=1350&q=80')
             center/cover no-repeat;
+  animation: fadeInUp .8s ease both;
 }
 .hero::after {            /* лёгкий градиент-оверлей */
   content: "";
   position: absolute; inset: 0;
-  background: linear-gradient(180deg, rgba(0,0,0,.3), rgba(0,0,0,.6));
+  background: linear-gradient(180deg, rgba(0,0,0,.25), rgba(0,0,0,.55));
 }
 .hero h1, .hero p { position: relative; z-index: 1; }
 .hero h1 { font-size: clamp(2.5rem, 7vw, 4rem); font-weight: 600; }
@@ -56,6 +61,12 @@ section { padding: 80px 0; }
   border: none;
   border-radius: 1rem;
   box-shadow: 0 8px 20px rgba(0,0,0,.05);
+  transition: transform .3s, box-shadow .3s;
+  animation: fadeInUp .6s ease both;
+}
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 24px rgba(0,0,0,.1);
 }
 .card-img-top { border-top-left-radius: 1rem; border-top-right-radius: 1rem; }
 /* ---------- Page hero ---------- */
@@ -65,13 +76,20 @@ section { padding: 80px 0; }
   background-size: cover;
   background-position: center;
   color: var(--light);
+  animation: fadeInUp .8s ease both;
 }
 .page-hero__overlay{
   content:"";position:absolute;inset:0;
-  background:linear-gradient(180deg,rgba(0,0,0,.35),rgba(0,0,0,.6));
+  background:linear-gradient(180deg,rgba(0,0,0,.25),rgba(0,0,0,.55));
 }
 
 /* Links in hero/button hover tweaks */
 .section-title + .row { margin-top: 2rem; }
 .table-info { background-color: rgba(78,138,158,.15) !important; }
 .card-footer .btn { border-radius: 50px; }
+
+/* ---------- Animations ---------- */
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: none; }
+}

--- a/public/blog.php
+++ b/public/blog.php
@@ -1,4 +1,34 @@
-<?php include 'includes/header.php'; ?>
-<h1>Blog</h1>
-<p>Read our latest articles.</p>
+<?php
+$title = 'Blog';
+$bg    = 'https://images.unsplash.com/photo-1554244933-d876deb6b2ff?auto=format&fit=crop&w=1400&q=80';
+include 'includes/header.php';
+include 'includes/hero.php';
+?>
+<section class="py-5">
+  <div class="container">
+    <div class="row g-4">
+      <div class="col-md-6 col-lg-4">
+        <article class="card h-100 shadow-sm">
+          <img src="https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?w=800" class="card-img-top" alt="">
+          <div class="card-body">
+            <h2 class="h5">5 Tips for Establishing a Daily Practice</h2>
+            <p class="card-text small">Consistency is key when it comes to yoga. Start with short sessions…</p>
+          </div>
+          <a href="#" class="stretched-link"></a>
+        </article>
+      </div>
+      <div class="col-md-6 col-lg-4">
+        <article class="card h-100 shadow-sm">
+          <img src="https://images.unsplash.com/photo-1551907234-314bb5725081?w=800" class="card-img-top" alt="">
+          <div class="card-body">
+            <h2 class="h5">Breathwork for Stress Relief</h2>
+            <p class="card-text small">Simple breathing exercises can calm the mind and reduce anxiety…</p>
+          </div>
+          <a href="#" class="stretched-link"></a>
+        </article>
+      </div>
+      <!-- добавляйте статьи циклом -->
+    </div>
+  </div>
+</section>
 <?php include 'includes/footer.php'; ?>

--- a/public/classes.php
+++ b/public/classes.php
@@ -1,4 +1,35 @@
-<?php include 'includes/header.php'; ?>
-<h1>Classes</h1>
-<p>Explore the variety of classes we offer.</p>
+<?php
+$title = 'Classes';
+$bg    = 'https://images.unsplash.com/photo-1596484557139-5c1c49b2abe0?auto=format&fit=crop&w=1400&q=80';
+include 'includes/header.php';
+include 'includes/hero.php';
+?>
+
+<section class="py-5">
+  <div class="container">
+    <h2 class="section-title">Choose your style</h2>
+    <div class="row g-4">
+      <?php
+      $classes = [
+        ['Vinyasa Flow', 'Dynamic practice linking breath and movement.', 'https://images.unsplash.com/photo-1554290764-4b62c1e6e23c?w=800'],
+        ['Hatha',        'Slower pace focusing on alignment and mindful breathing.', 'https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?w=800'],
+        ['Restorative',  'Gentle poses with props to calm the nervous system.', 'https://images.unsplash.com/photo-1540206395-68808572332f?w=800'],
+        ['Yin',          'Deep stretch with long holds to target connective tissue.', 'https://images.unsplash.com/photo-1531938712298-28d17f8f033b?w=800'],
+        ['Power Yoga',   'Fast-paced, sweat-inducing flow for strength.', 'https://images.unsplash.com/photo-1562072849-1cac0bbb6b47?w=800'],
+        ['Prenatal',     'Safe practice supporting expecting mothers.', 'https://images.unsplash.com/photo-1557336059-3513e6873474?w=800'],
+      ];
+      foreach ($classes as [$name,$text,$img]): ?>
+        <div class="col-md-4">
+          <div class="card h-100 shadow-sm">
+            <img src="<?= $img ?>" class="card-img-top" alt="<?= $name ?>">
+            <div class="card-body text-center">
+              <h5 class="card-title"><?= $name ?></h5>
+              <p class="card-text"><?= $text ?></p>
+            </div>
+          </div>
+        </div>
+      <?php endforeach; ?>
+    </div>
+  </div>
+</section>
 <?php include 'includes/footer.php'; ?>

--- a/public/contact.php
+++ b/public/contact.php
@@ -1,4 +1,13 @@
-<?php include 'includes/header.php'; ?>
-<h1>Contact Us</h1>
-<p>Get in touch for more information.</p>
+<?php
+$title = 'Contact';
+$bg    = 'https://images.unsplash.com/photo-1526045612212-70caf35c14df?auto=format&fit=crop&w=1400&q=80';
+include 'includes/header.php';
+include 'includes/hero.php';
+?>
+<section class="py-5">
+  <div class="container">
+    <h1 class="mb-4">Contact Us</h1>
+    <p>Get in touch for more information.</p>
+  </div>
+</section>
 <?php include 'includes/footer.php'; ?>

--- a/public/gallery.php
+++ b/public/gallery.php
@@ -1,4 +1,29 @@
-<?php include 'includes/header.php'; ?>
-<h1>Gallery</h1>
-<p>View photos from our classes.</p>
+<?php
+$title = 'Gallery';
+$bg    = 'https://images.unsplash.com/photo-1545205597-3d02a9d7b76e?auto=format&fit=crop&w=1400&q=80';
+include 'includes/header.php';
+include 'includes/hero.php';
+?>
+<section class="py-5">
+  <div class="container">
+    <p class="lead text-center mb-5">A glimpse into our classes and community</p>
+
+    <div class="row g-4" data-masonry='{"percentPosition": true }'>
+      <?php
+      // можно заменить на реальный цикл из БД
+      $pics = [
+        'https://images.unsplash.com/photo-1551907234-314bb5725081?w=800',
+        'https://images.unsplash.com/photo-1518611012118-696072aa579a?w=800',
+        'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?w=800',
+        'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=800',
+        'https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?w=800'
+      ];
+      foreach ($pics as $src): ?>
+        <div class="col-6 col-md-4 col-lg-3">
+          <img class="img-fluid rounded shadow-sm" src="<?= $src ?>" alt="Yoga studio">
+        </div>
+      <?php endforeach; ?>
+    </div>
+  </div>
+</section>
 <?php include 'includes/footer.php'; ?>

--- a/public/includes/footer.php
+++ b/public/includes/footer.php
@@ -1,4 +1,4 @@
-</div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
 </body>
 </html>

--- a/public/includes/header.php
+++ b/public/includes/header.php
@@ -26,6 +26,7 @@ $links = [
 
   <!-- Bootstrap 5 -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
 
   <!-- Google Font + кастомные стили -->
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
@@ -59,5 +60,3 @@ $links = [
     </div>
   </div>
 </nav>
-
-<div class="container mt-4">

--- a/public/includes/hero.php
+++ b/public/includes/hero.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * hero.php
+ * Показывает большой баннер-обложку.
+ * Ожидает $title и $bg (URL фона). Цвет текста берётся автоматом (светлый).
+ */
+?>
+<section class="page-hero d-flex align-items-center text-center"
+         style="background-image:url('<?= $bg ?>');">
+  <div class="container position-relative z-1">
+    <h1 class="display-4 fw-semibold"><?= $title ?></h1>
+  </div>
+  <div class="page-hero__overlay"></div>
+</section>

--- a/public/instructors.php
+++ b/public/instructors.php
@@ -1,4 +1,29 @@
-<?php include 'includes/header.php'; ?>
-<h1>Instructors</h1>
-<p>Meet our experienced instructors.</p>
+<?php
+$title = 'Instructors';
+$bg    = 'https://images.unsplash.com/photo-1522199755839-a2bacb67c546?auto=format&fit=crop&w=1400&q=80';
+include 'includes/header.php';
+include 'includes/hero.php';
+?>
+<section class="py-5">
+  <div class="container">
+    <p class="lead text-center mb-5">Our certified teachers guide you through every pose</p>
+    <div class="row g-4">
+      <!-- пример одной карточки -->
+      <div class="col-md-4">
+        <div class="card h-100 text-center shadow-sm">
+          <img src="https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=800" class="card-img-top" alt="Anna Petrova">
+          <div class="card-body">
+            <h5 class="card-title">Anna Petrova</h5>
+            <p class="card-text small">Certified yoga therapist with 10+ years of teaching experience.</p>
+          </div>
+          <div class="card-footer bg-transparent border-0 pb-4">
+            <a href="#" class="btn btn-outline-primary btn-sm me-1"><i class="bi bi-instagram"></i></a>
+            <a href="#" class="btn btn-outline-primary btn-sm"><i class="bi bi-facebook"></i></a>
+          </div>
+        </div>
+      </div>
+      <!-- дублируйте/заменяйте остальные -->
+    </div>
+  </div>
+</section>
 <?php include 'includes/footer.php'; ?>

--- a/public/packages.php
+++ b/public/packages.php
@@ -1,4 +1,13 @@
-<?php include 'includes/header.php'; ?>
-<h1>Packages</h1>
-<p>Choose the best package for you.</p>
+<?php
+$title = 'Packages';
+$bg    = 'https://images.unsplash.com/photo-1549237514-b045cbd7e055?auto=format&fit=crop&w=1400&q=80';
+include 'includes/header.php';
+include 'includes/hero.php';
+?>
+<section class="py-5">
+  <div class="container">
+    <h1 class="mb-4">Packages</h1>
+    <p>Choose the best package for you.</p>
+  </div>
+</section>
 <?php include 'includes/footer.php'; ?>

--- a/public/schedule.php
+++ b/public/schedule.php
@@ -1,4 +1,35 @@
-<?php include 'includes/header.php'; ?>
-<h1>Schedule</h1>
-<p>Check out our class schedule.</p>
+<?php
+$title = 'Schedule';
+$bg    = 'https://images.unsplash.com/photo-1506334572581-344b256329f4?auto=format&fit=crop&w=1400&q=80';
+include 'includes/header.php';
+include 'includes/hero.php';
+
+$today = date('l');            // Monday, Tuesday…
+$rows  = [
+  ['Monday',    '08:00', 'Hatha'],
+  ['Tuesday',   '18:30', 'Vinyasa Flow'],
+  ['Wednesday', '20:00', 'Restorative'],
+  ['Thursday',  '07:00', 'Morning Flow'],
+  ['Saturday',  '10:00', 'Mixed Level'],
+];
+?>
+<section class="py-5">
+  <div class="container">
+    <h2 class="section-title">This week</h2>
+    <div class="table-responsive">
+      <table class="table table-striped align-middle">
+        <thead class="table-light">
+          <tr><th>Day</th><th>Time</th><th>Class</th></tr>
+        </thead>
+        <tbody>
+        <?php foreach ($rows as [$day,$time,$class]): ?>
+          <tr <?= $day === $today ? 'class="table-info fw-semibold"' : '' ?>>
+            <td><?= $day ?></td><td><?= $time ?></td><td><?= $class ?></td>
+          </tr>
+        <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
 <?php include 'includes/footer.php'; ?>

--- a/public/signup.php
+++ b/public/signup.php
@@ -1,5 +1,12 @@
-<?php include 'includes/header.php'; ?>
-<h1>Sign Up for a Class</h1>
+<?php
+$title = 'Sign Up';
+$bg    = 'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1400&q=80';
+include 'includes/header.php';
+include 'includes/hero.php';
+?>
+<section class="py-5">
+<div class="container">
+  <h1 class="mb-4">Sign Up for a Class</h1>
 <?php if (!empty($_GET['success'])): ?>
 <div class="alert alert-success">Thank you for signing up!</div>
 <?php endif; ?>
@@ -14,4 +21,6 @@
   </div>
   <button type="submit" class="btn btn-primary">Submit</button>
 </form>
+</div>
+</section>
 <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add reusable page hero component
- update header/footer with icons and masonry support
- restyle pages to use the hero banner and cards
- tweak style sheet for hero and other small improvements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fc3da7a4483218453b571e30d9bf0