### PR TITLE
Add reusable trial signup form module

### DIFF
--- a/create_table.sql
+++ b/create_table.sql
@@ -1,9 +1,4 @@
-CREATE TABLE IF NOT EXISTS signups (
-    id SERIAL PRIMARY KEY,
-    full_name TEXT NOT NULL,
-    email TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
+
 
 CREATE TABLE IF NOT EXISTS trial_signups (
     id SERIAL PRIMARY KEY,

--- a/create_table.sql
+++ b/create_table.sql
@@ -4,3 +4,11 @@ CREATE TABLE IF NOT EXISTS signups (
     email TEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS trial_signups (
+    id SERIAL PRIMARY KEY,
+    full_name TEXT NOT NULL,
+    phone TEXT NOT NULL,
+    email TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/public/assets/css/components/trial-form.css
+++ b/public/assets/css/components/trial-form.css
@@ -1,0 +1,102 @@
+.trial-form-section {
+    padding: 60px 20px;
+    background: #f7f4f0;
+    display: flex;
+    justify-content: center;
+}
+
+.trial-form-section .form-container {
+    background-color: rgba(255, 255, 255, 0.9);
+    padding: 40px;
+    border-radius: 15px;
+    width: 100%;
+    max-width: 600px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.trial-form-section .header {
+    text-align: center;
+    margin-bottom: 40px;
+}
+
+.trial-form-section h1 {
+    font-size: 32px;
+    color: #333;
+    margin-bottom: 10px;
+}
+
+.trial-form-section .price {
+    font-size: 24px;
+    font-weight: bold;
+    color: #333;
+    margin-bottom: 10px;
+}
+
+.trial-form-section .free-offer {
+    font-size: 16px;
+    color: #666;
+    font-style: italic;
+}
+
+.trial-form-section .form-group {
+    position: relative;
+    margin-bottom: 24px;
+}
+
+.trial-form-section input {
+    width: 100%;
+    padding: 16px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    font-size: 16px;
+    background-color: #f9f9f9;
+}
+
+.trial-form-section label {
+    position: absolute;
+    left: 16px;
+    top: 16px;
+    color: #999;
+    font-size: 16px;
+    transition: all 0.3s ease;
+    pointer-events: none;
+}
+
+.trial-form-section input:focus + label,
+.trial-form-section input:not(:placeholder-shown) + label {
+    top: -10px;
+    left: 10px;
+    font-size: 12px;
+    background-color: #fff;
+    padding: 0 5px;
+    color: #098950;
+}
+
+.trial-form-section button {
+    background-color: #098950;
+    color: #fff;
+    border: none;
+    padding: 16px;
+    width: 50%;
+    border-radius: 8px;
+    font-size: 18px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: background-color 0.3s;
+    margin: 0 auto;
+    display: block;
+}
+
+.trial-form-section button:hover {
+    background-color: #45a049;
+}
+
+.trial-form-section .trial-success {
+    text-align: center;
+    color: #098950;
+    margin-bottom: 20px;
+    font-weight: bold;
+}

--- a/public/includes/header.php
+++ b/public/includes/header.php
@@ -6,9 +6,18 @@
   <link href="https://fonts.googleapis.com/css2?family=Mr+Dafoe&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Montserrat:400,500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/css/main.css">
-<?php if (isset($pageCss)): ?>
-  <link rel="stylesheet" href="<?= $pageCss ?>">
-<?php endif; ?>
+<?php
+  $styles = [];
+  if (isset($pageCss)) {
+      $styles = is_array($pageCss) ? $pageCss : [$pageCss];
+  }
+  if (isset($extraCss)) {
+      $styles = array_merge($styles, is_array($extraCss) ? $extraCss : [$extraCss]);
+  }
+  foreach ($styles as $css) {
+      echo "  <link rel=\"stylesheet\" href=\"$css\">\n";
+  }
+?>
 </head>
 <body>
 <header class="main-header">

--- a/public/includes/trial-form.php
+++ b/public/includes/trial-form.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Trial signup form component.
+ * Expects $trialSuccess boolean flag to show success message.
+ */
+?>
+<section class="trial-form-section">
+  <div class="form-container">
+    <div class="header">
+        <h1>Первая тренировка</h1>
+        <div class="price">500 рублей</div>
+        <div class="free-offer">*Бесплатно — при покупке абонемента в этот же день</div>
+    </div>
+    <?php if (!empty($trialSuccess)): ?>
+      <div class="trial-success">Спасибо! Мы свяжемся с вами.</div>
+    <?php endif; ?>
+    <form action="/submit_trial.php" method="POST">
+        <div class="form-group">
+            <input type="text" id="name" name="name" placeholder=" " required>
+            <label for="name">Имя</label>
+        </div>
+
+        <div class="form-group">
+            <input type="tel" id="phone" name="phone" placeholder=" " required>
+            <label for="phone">Номер телефона</label>
+        </div>
+
+        <div class="form-group">
+            <input type="email" id="email" name="email" placeholder=" " required>
+            <label for="email">Электронная почта</label>
+        </div>
+
+        <button type="submit">Записаться</button>
+    </form>
+  </div>
+</section>

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,8 @@
 <?php
 $pageCss = '/assets/css/pages/home.css';
+$extraCss = '/assets/css/components/trial-form.css';
 include 'includes/header.php';
+$trialSuccess = !empty($_GET['trial_success']);
 ?>
 <main class="directions">
     <div class="directions-header">
@@ -42,4 +44,5 @@ include 'includes/header.php';
         </div>
     </div>
 </main>
+<?php include 'includes/trial-form.php'; ?>
 <?php include 'includes/footer.php'; ?>

--- a/public/pages/home.php
+++ b/public/pages/home.php
@@ -1,6 +1,8 @@
 <?php
 $pageCss = '/assets/css/pages/home.css';
+$extraCss = '/assets/css/components/trial-form.css';
 include '../includes/header.php';
+$trialSuccess = !empty($_GET['trial_success']);
 ?>
 <main class="directions">
     <div class="directions-header">
@@ -42,4 +44,5 @@ include '../includes/header.php';
         </div>
     </div>
 </main>
+<?php include '../includes/trial-form.php'; ?>
 <?php include '../includes/footer.php'; ?>

--- a/public/submit_trial.php
+++ b/public/submit_trial.php
@@ -1,0 +1,18 @@
+<?php
+require 'includes/db.php';
+
+$name  = $_POST['name']  ?? '';
+$phone = $_POST['phone'] ?? '';
+$email = $_POST['email'] ?? '';
+
+if ($name && $phone && $email) {
+    $stmt = $pdo->prepare('INSERT INTO trial_signups (full_name, phone, email) VALUES (:name, :phone, :email)');
+    $stmt->execute([':name' => $name, ':phone' => $phone, ':email' => $email]);
+    $ref = $_SERVER['HTTP_REFERER'] ?? '/';
+    $sep = str_contains($ref, '?') ? '&' : '?';
+    header("Location: {$ref}{$sep}trial_success=1");
+    exit;
+}
+
+header('Location: ' . ($_SERVER['HTTP_REFERER'] ?? '/'));
+?>


### PR DESCRIPTION
## Summary
- add `trial_signups` table to `create_table.sql`
- update header to handle multiple css files
- create trial form component with processing script
- include the form on the home page and index page
- add component stylesheet

## Testing
- `php -l public/includes/trial-form.php`
- `php -l public/submit_trial.php`
- `php -l public/pages/home.php`
- `php -l public/index.php`
- `php -l public/includes/header.php`


------
https://chatgpt.com/codex/tasks/task_e_686176123c0c83219b8674dbd9a60075